### PR TITLE
Add travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+
+env:
+- GO111MODULE=on
+
+go:
+- 1.12.x
+
+notifications:
+  # Don't email the results of the test runs.
+  email: false
+
+script:
+- go test -v -race ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,11 @@ notifications:
   # Don't email the results of the test runs.
   email: false
 
+before_script:
+- go get -u golang.org/x/lint/golint
+
 script:
+- go build
 - go test -v -race ./...
+- golint -set_exit_status ./...
+- docker build .


### PR DESCRIPTION
Adds a short config to make sure go test passes. I've also tried adding golangci-lint but the upstream currently doesn't pass all default lints.